### PR TITLE
Support bin string

### DIFF
--- a/lib/shelljs-nodecli.js
+++ b/lib/shelljs-nodecli.js
@@ -31,6 +31,24 @@ function getPackage(name, root) {
     return test("-f", packagePath) ? JSON.parse(fs.readFileSync(packagePath, "utf8")) : null;
 }
 
+/**
+ * Retrieves a binary from the given package.
+ * @param {*} pkg the node package
+ * @param {*} name the binary name to look for
+ * @returns {string} The path to the binary.
+ * @private
+ */
+function getBin(pkg, name) {
+    if (pkg) {
+        if (typeof pkg.bin === "string" && pkg.name === name) {
+            return pkg.bin;
+        } else if (typeof pkg.bin === "object") {
+            return pkg.bin[name];
+        }
+    }
+
+    return null;
+}
 
 //------------------------------------------------------------------------------
 // Public
@@ -54,12 +72,10 @@ module.exports = {
      */
     getPath: function(name, root) {
 
-        var pkg = getPackage(name, root || "");
+        var bin = getBin(getPackage(name, root || ""), name);
 
-        if (pkg) {
-            if (pkg.bin && pkg.bin[name]) {
-                return "node " + path.join(root || "", "node_modules", name, pkg.bin[name]).replace(/\\/g, "/");
-            }
+        if (bin) {
+            return "node " + path.join(root || "", "node_modules", name, bin).replace(/\\/g, "/");
         } else if (which(name)) {
             return name;
         }


### PR DESCRIPTION
Support for bin string fields.

As described here: https://docs.npmjs.com/files/package.json#bin bin field can also be a single string when the package name matches the binary name.

This change is required to work OK with yarn, or linking local modules. Otherwise npm normalizes the package.json and this case does not occur.