### PR TITLE
Add missing fixture file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 coverage/
 npm-debug.log
-node_modules/
+/node_modules
 

--- a/tests/fixtures/node_modules/testmodule/package.json
+++ b/tests/fixtures/node_modules/testmodule/package.json
@@ -1,0 +1,5 @@
+{
+  "bin": {
+    "testmodule": "test.js"
+  }
+}


### PR DESCRIPTION
When I cloned this repo locally and ran the tests, the [first test](https://github.com/nzakas/shelljs-nodecli/blob/e73739f79eace005c5d24169d3e91ec744f7e732/tests/lib/shelljs-nodecli-test.js#L51-L54) failed. I suspect this is because the fixture file is missing from the repository. The `.gitignore` file is causing *all* `node_modules` folders to be ignored rather than just the top-level `node_modules` folder.

This commit fixes `.gitignore` and adds the missing fixture file to make the tests pass.