### PR TITLE
Avoid overwriting shelljs globals

### DIFF
--- a/lib/shelljs-nodecli.js
+++ b/lib/shelljs-nodecli.js
@@ -2,17 +2,17 @@
  * @fileoverview ShellJS Node CLI Extension
  * @author Nicholas C. Zakas
  */
-/*global exec, which, test, echo*/
 "use strict";
 
 //------------------------------------------------------------------------------
 // Requirements
 //------------------------------------------------------------------------------
 
-require("shelljs/global");
-
 var path = require("path"),
-    fs = require("fs");
+    fs = require("fs"),
+    shell = require("shelljs");
+
+var exec = shell.exec;
 
 //------------------------------------------------------------------------------
 // Private
@@ -28,7 +28,7 @@ var path = require("path"),
  */
 function getPackage(name, root) {
     var packagePath = path.join(root || "", "node_modules", name, "package.json");
-    return test("-f", packagePath) ? JSON.parse(fs.readFileSync(packagePath, "utf8")) : null;
+    return shell.test("-f", packagePath) ? JSON.parse(fs.readFileSync(packagePath, "utf8")) : null;
 }
 
 
@@ -60,7 +60,7 @@ module.exports = {
             if (pkg.bin && pkg.bin[name]) {
                 return "node " + path.join(root || "", "node_modules", name, pkg.bin[name]).replace(/\\/g, "/");
             }
-        } else if (which(name)) {
+        } else if (shell.which(name)) {
             return name;
         }
 

--- a/tests/lib/shelljs-nodecli-test.js
+++ b/tests/lib/shelljs-nodecli-test.js
@@ -99,6 +99,20 @@ describe("nodeCLI", function() {
 
 	});
 
+	describe("loading", function() {
+		it("does not override existing globals", function() {
+			var otherExec = function() {};
 
+			global.exec = otherExec;
+
+			Object.keys(require.cache).forEach(function(key) {
+				delete require.cache[key];
+			});
+
+			require("../..");
+
+			assert.equal(global.exec, otherExec);
+		});
+	});
 
 });


### PR DESCRIPTION
While working on a fix for an ESLint build issue, I tried to make a change like this in ESLint's `Makefile.js`:

```diff
/* global exec */
require("shelljs/global");
const nodeCLI = require("shelljs-nodecli");

// ...

-exec("foo");
+exec("foo", { env: { SOME_ENVIRONMENT_VARIABLE: "1" });
```

However, setting the environment variable wasn't working, even though `shelljs.exec` is supposed to support an `env` option. After being confused for a few minutes, I realized that `shelljs-nodecli` was overwriting the `exec` global with an older version of the `shelljs.exec` function, which doesn't support the `env` option.

This commit updates `shelljs-nodecli` to use methods from `shelljs` directly rather than overwriting globals.